### PR TITLE
Store user configured filters in localStorage

### DIFF
--- a/src/shared/scripts/global.js
+++ b/src/shared/scripts/global.js
@@ -1,4 +1,11 @@
-const READING_SPEED = 200;
+const LOCAL_PREFERENCE_PREFIX = "_godot_up"
+const LOCAL_PREFERENCE_DEFAULTS = {
+  "sortBy"          : "age",
+  "sortDirection"   : "desc",
+  "showDraft"       : false,
+  "filterMilestone" : "4.0",
+  "filterMergeable" : "",
+};
 
 // API Interaction
 const ReportsAPI = {
@@ -82,6 +89,33 @@ const ReportsUtils = {
     const url = new URL(window.location);
     url.hash = hash;
     window.history.pushState({}, "", url);
+  },
+
+  getLocalPreferences() {
+    // Always fallback on defaults.
+    const localPreferences = { ...LOCAL_PREFERENCE_DEFAULTS };
+
+    for (let key in localPreferences) {
+      const storedValue = localStorage.getItem(`${LOCAL_PREFERENCE_PREFIX}_${key}`);
+      if (storedValue != null) {
+        localPreferences[key] = JSON.parse(storedValue);
+      }
+    }
+
+    return localPreferences;
+  },
+
+  setLocalPreferences(currentPreferences) {
+    for (let key in currentPreferences) {
+      // Only store known properties.
+      if (key in LOCAL_PREFERENCE_DEFAULTS) {
+        localStorage.setItem(`${LOCAL_PREFERENCE_PREFIX}_${key}`, JSON.stringify(currentPreferences[key]));
+      }
+    }
+  },
+
+  resetLocalPreferences() {
+    this.setLocalPreferences(LOCAL_PREFERENCE_DEFAULTS);
   },
 };
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-team-reports/issues/11.

Now when you change filters or sorting options, they are immediately stored in the browser's local storage and are automatically applied upon the next page load. There is also a reset to defaults button, just in case.

Note, that if some team/reviewer doesn't have the milestone you have selected, it will display all PRs, but the stored filter would not change and when you return to the previous team/reviewer that _does_ have that milestone it will be correctly displayed. I think this gives more consistency to users when switching between different teams/reviewers.